### PR TITLE
Add trillium.rs

### DIFF
--- a/trillium/Cargo.toml
+++ b/trillium/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "trillium"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+trillium = "0.1.5"
+trillium-smol = "0.1.4"

--- a/trillium/src/main.rs
+++ b/trillium/src/main.rs
@@ -1,0 +1,9 @@
+use trillium::Conn;
+
+async fn hello_world(conn: Conn) -> Conn {
+    conn.ok("Hello, world!")
+}
+
+fn main() {
+    trillium_smol::run(hello_world)
+}


### PR DESCRIPTION
By default, trillium will bind to localhost:8080, but will pick up HOST and PORT env vars if needed